### PR TITLE
Fix a format bug

### DIFF
--- a/ox-nikola.el
+++ b/ox-nikola.el
@@ -215,7 +215,8 @@ holding export options."
      (cond ((not (string= "" previewimage))
             (concat "\n.. previewimage: " previewimage)))
      (cond ((not (string= "" enclosure))
-            (concat "\n.. enclosure: " enclosure))))))
+            (concat "\n.. enclosure: " enclosure)))
+     "\n")))
 
 
 ;;; End-User functions


### PR DESCRIPTION
When optional argument SUBTREEP of org-nikola-export-to-rst or
org-nikola-export-as-rst is non-nil, the result will be falsely formatted.

Example:

Call (org-nikola-export-as-rst nil t) on this entry:

```
* foo  
  bar
```

Result:

```
  .. title: foo
  .. slug: foo
  .. date:
  .. tags:
  .. link:
  .. description:
  .. type: text
  .. author: Meiyo Pengbar
```
